### PR TITLE
Windows fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@ Documentation
 
 [API Documentation][docs]
 
+### Prerequisites
+
+On Windows you need to have LLVM installed, as it is needed by bindgen.  
+To do that you can Install [Chocolatey](https://chocolatey.org/) and then from command line:
+```
+choco install llvm
+```
+
+### Building
+
+Clone repository and Update submodules
+```
+git clone https://github.com/jazzay/bgfx-rs.git
+cd bgfx-rs
+git submodule update --init --recursive
+```
+Build
+```
+cargo build
+```
+
 ### Examples
 
 To run the examples, invoke them through cargo:
@@ -26,11 +47,6 @@ cargo run --example 00-helloworld
 cargo run --example 01-cubes
 ```
 
-**OSX Note:** There is currently no really clean way to exit the examples in
-OSX, and closing the window may in fact cause a crash. This is due to
-limitations in [glutin][glutin] (specifically [#468] and [#520]). This only
-effects the examples, and not the crate itself. The best way of closing them
-is to simply `Ctrl-C` in the console.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation
 
 [API Documentation][docs]
 
-### Prerequisites
+## Prerequisites
 
 On Windows you need to have LLVM installed, as it is needed by bindgen.  
 To do that you can Install [Chocolatey](https://chocolatey.org/) and then from command line:
@@ -25,7 +25,7 @@ To do that you can Install [Chocolatey](https://chocolatey.org/) and then from c
 choco install llvm
 ```
 
-### Building
+## Building
 
 Clone repository and Update submodules
 ```
@@ -33,12 +33,21 @@ git clone https://github.com/jazzay/bgfx-rs.git
 cd bgfx-rs
 git submodule update --init --recursive
 ```
-Build
+### Building for Non-Windows
 ```
 cargo build
 ```
+### Building for Windows
+Due to a dependency issue (shaderc) you need to build the sys first so that it copies the shaderc binary properly on Windows. Hopefully we can improve this in the future. After this you can successfully build and run the examples as below.
 
-### Examples
+```
+cd bgfx-sys
+cargo build
+cd ..
+cargo build
+```
+
+## Examples
 
 To run the examples, invoke them through cargo:
 

--- a/examples_lib/src/lib.rs
+++ b/examples_lib/src/lib.rs
@@ -6,7 +6,11 @@ extern crate winit;
 
 use bgfx::{Bgfx, PlatformData, RenderFrame, RendererType};
 
+#[cfg(target_os = "macos")]
 use winit::os::macos::WindowExt;
+
+#[cfg(target_os = "windows")]
+use winit::os::windows::WindowExt;
 
 use std::env;
 use std::fs::File;
@@ -136,6 +140,11 @@ fn init_bgfx_platform(window: &Window) {
 #[cfg(target_os = "macos")]
 fn get_platform_window(window: &winit::Window) -> *mut std::os::raw::c_void {
   return window.get_nswindow();
+}
+
+#[cfg(target_os = "windows")]
+fn get_platform_window(window: &winit::Window) -> *mut std::os::raw::c_void {
+  return window.get_hwnd() as *mut std::os::raw::c_void;
 }
 
 /// Set the platform data to be used by BGFX.


### PR DESCRIPTION
Updated build.rs to include building of BGFX tools on windows, and copy shaderc to the expected location so that the following builds (examples, etc) can work properly. Note that due to how the crate is currently structured you have to build the inner bgfx-sys first on windows so that the shader binary exists prior to running the outer build for the examples. Updated Readme with proper working instructions for others.